### PR TITLE
Add build workflow for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install SDL2
+        run: sudo apt-get update && sudo apt-get install -y libsdl2-dev
+      - name: Build
+        run: make copy-release
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: raytracer
+          path: releases/raytracer.exe
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: releases/raytracer.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ the `releases` folder. Afterwards you can run the program again with:
 ```
 
 Close the window to exit the program.
+
+## GitHub Releases
+
+Push a tag starting with `v` (for example `v1.0.0`) to trigger the GitHub Actions workflow. The workflow compiles the executable and attaches `raytracer.exe` to the release.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <SDL2/SDL.h>
 #include <iostream>
+#include <algorithm>
 #include "renderer.h"
 
 int main() {


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and upload `raytracer.exe`
- document how to trigger automated releases

## Testing
- `make copy-release` *(fails: SDL2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f5e92d0008331af63d300d34edcfd