### PR TITLE
Add MinGW support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install SDL2
-        run: sudo apt-get update && sudo apt-get install -y libsdl2-dev
+      - name: Install SDL2 and MinGW
+        run: sudo apt-get update && sudo apt-get install -y libsdl2-dev mingw-w64
       - name: Build
-        run: make copy-release
+        run: make CXX=x86_64-w64-mingw32-g++ SDL_CONFIG=x86_64-w64-mingw32-sdl2-config copy-release
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-CXX = g++
-CXXFLAGS = -std=c++17
-LDFLAGS = -lSDL2
+# C++ compiler and SDL configuration tool can be overridden from the command
+# line to enable cross compilation with MinGW.
+CXX ?= g++
+SDL_CONFIG ?= sdl2-config
+CXXFLAGS = -std=c++17 $(shell $(SDL_CONFIG) --cflags)
+LDFLAGS = $(shell $(SDL_CONFIG) --libs)
 SRCS = $(wildcard src/*.cpp)
 TARGET = raytracer.exe
 

--- a/README.md
+++ b/README.md
@@ -2,19 +2,30 @@
 
 This project is a very small example ray tracer implemented in C++. It now opens an SDL2 window showing a reflective sphere hovering above a floor.
 
-## Building and running
+## Dependencies
 
-This project uses a small `Makefile`. Ensure SDL2 is installed and simply run:
+The project depends on SDL2. On Debian based distributions you can install the
+development libraries together with the MinGW toolchain for cross compilation:
 
 ```bash
-make
+sudo apt-get update
+sudo apt-get install -y libsdl2-dev mingw-w64
 ```
 
-The command compiles `raytracer.exe`, launches it, and copies the executable to
-the `releases` folder. Afterwards you can run the program again with:
+## Building and running
+
+The provided `Makefile` supports building both natively and with MinGW. To
+produce a Windows executable on Linux run:
 
 ```bash
-./raytracer.exe
+make CXX=x86_64-w64-mingw32-g++ SDL_CONFIG=x86_64-w64-mingw32-sdl2-config
+```
+
+The command compiles `raytracer.exe` and copies it to the `releases` folder.
+You can run the program on Windows or with Wine:
+
+```bash
+wine ./raytracer.exe
 ```
 
 Close the window to exit the program.


### PR DESCRIPTION
## Summary
- allow overriding compiler and SDL2 config in Makefile
- document SDL2 and mingw-w64 dependencies and cross-build instructions
- install mingw-w64 in GitHub workflow and cross-compile using it

## Testing
- `make raytracer.exe`

------
https://chatgpt.com/codex/tasks/task_e_683f6840f774833180d5b5140d340a73