### PR TITLE
Improve camera movement and controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ wine ./raytracer.exe
 ```
 
 Close the window to exit the program.
-Use the arrow keys to move the camera horizontally and forward/backward. Press
-`Q` to raise the camera, `E` to lower it, and `W`/`S` to pitch the camera up or
-down.
+Use `W`, `A`, `S`, `D` to move forward, left, back and right relative to the
+current view. `Q` moves up, `E` moves down. Hold multiple keys at once to move
+diagonally. Look around with the arrow keys (`←`/`→` yaw, `↑`/`↓` pitch).
 
 
 ## GitHub Releases


### PR DESCRIPTION
## Summary
- add yaw and WASD movement for first-person navigation
- use arrow keys for looking around
- allow simultaneous key presses with per-frame polling
- update README with new controls

## Testing
- `make raytracer.exe`

------
https://chatgpt.com/codex/tasks/task_e_68402b7b5ca0833194152f8e4554e857