### PR TITLE
Fix Windows build without Vulkan support

### DIFF
--- a/external/imgui/backends/imgui_impl_sdl2.cpp
+++ b/external/imgui/backends/imgui_impl_sdl2.cpp
@@ -125,7 +125,16 @@
 #define SDL_HAS_VULKAN                      SDL_VERSION_ATLEAST(2,0,6)
 #define SDL_HAS_OPEN_URL                    SDL_VERSION_ATLEAST(2,0,14)
 #if SDL_HAS_VULKAN
+#if defined(__has_include)
+#if __has_include(<SDL_vulkan.h>)
 #include <SDL_vulkan.h>
+#else
+#undef SDL_HAS_VULKAN
+#define SDL_HAS_VULKAN 0
+#endif
+#else
+#include <SDL_vulkan.h>
+#endif
 #endif
 
 // SDL Data


### PR DESCRIPTION
## Summary
- check for SDL_vulkan.h in the SDL2 backend and disable Vulkan sections if the header is missing

## Testing
- `make copy-release`
- `make CXX=x86_64-w64-mingw32-g++ SDL_CONFIG="echo" CXXFLAGS="-std=c++17 -I$(pwd)/deps/SDL2-2.30.2/x86_64-w64-mingw32/include" LDFLAGS="-L$(pwd)/deps/SDL2-2.30.2/x86_64-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2 -mwindows" copy-release`


------
https://chatgpt.com/codex/tasks/task_e_68403454e91c83319c26984085af8018